### PR TITLE
Support custom clients

### DIFF
--- a/lib/node-redis-pubsub.js
+++ b/lib/node-redis-pubsub.js
@@ -14,9 +14,17 @@ function NodeRedisPubsub (options) {
     var host = options && options.host || '127.0.0.1';
     var auth = options && options.auth;
 
+    function createClient() {
+        if (options && options.createClient) {
+            return options.createClient();
+        } else {
+            return redis.createClient(port, host);
+        }
+    };
+
     // Need to create two Redis clients as one cannot be both in receiver and emitter mode
-    this.emitter = redis.createClient(port, host);
-    this.receiver = redis.createClient(port, host);
+    this.emitter = createClient();
+    this.receiver = createClient();
 
     if (auth) {
         this.emitter.auth(auth);

--- a/test/redisPubsub.test.js
+++ b/test/redisPubsub.test.js
@@ -1,4 +1,6 @@
-var should = require('chai').should()
+var redis = require('redis')
+  , should = require('chai').should()
+  , expect = require('chai').expect
   , conf = { port: 6379, scope: 'onescope' }
   , conf2 = { port: 6379, scope: 'anotherscope' }
   , conf3 = {}
@@ -135,4 +137,17 @@ describe('Node Redis Pubsub', function () {
     });
   });
 
+
+  it('Should allow custom clients', function () {
+    var count = 0;
+
+    new NodeRedisPubsub({
+        createClient: function() {
+            count++;
+            return redis.createClient();
+        }
+    });
+
+    expect(count).equal(2);
+  });
 });


### PR DESCRIPTION
Add support for custom clients, i.e., using https://github.com/ortoo/node-redis-sentinel.
